### PR TITLE
Refactor SerialManager to dynamic drivers + transport; add identify() and fix logger duplication

### DIFF
--- a/benchmesh-serial-service/src/benchmesh_service/drivers/owon_oel.py
+++ b/benchmesh-serial-service/src/benchmesh_service/drivers/owon_oel.py
@@ -1,45 +1,18 @@
-import serial
-import time
+from ..transport import SerialTransport
 
 class OwonOEL:
-    def __init__(self, port, baudrate=115200):
-        self.port = port
-        self.baudrate = baudrate
-        self.ser = None
-        self.connect()
+    def __init__(self, port, baudrate=115200, serial_mode='8N1', seol='\r', reol='\r'):
+        self.t = SerialTransport(port, baudrate, serial_mode=serial_mode, seol=seol, reol=reol).open()
 
-    def connect(self):
-        self.ser = serial.Serial(
-            port=self.port,
-            baudrate=self.baudrate,
-            bytesize=serial.EIGHTBITS,
-            parity=serial.PARITY_NONE,
-            stopbits=serial.STOPBITS_ONE,
-            timeout=1.0
-        )
-        time.sleep(0.2)
+    def identify(self):
+        self.t.write_line('*IDN?')
+        return self.t.read_until_reol(1024)
 
-    def write(self, command):
-        if self.ser and self.ser.is_open:
-            self.ser.write(command)
+    def write(self, data: bytes):
+        self.t.write(data)
 
     def read(self, size=1024):
-        if self.ser and self.ser.is_open:
-            return self.ser.read(size)
-        return None
-
-    def check_status(self):
-        if self.ser and self.ser.is_open:
-            try:
-                self.ser.write(b'*IDN?\r')
-                time.sleep(0.2)
-                reply = self.ser.read(1024)
-                return reply
-            except Exception as e:
-                print(f"Error checking status: {e}")
-                self.connect()  # Attempt to reconnect on error
-        return None
+        return self.t.read(size)
 
     def close(self):
-        if self.ser:
-            self.ser.close()
+        self.t.close()

--- a/benchmesh-serial-service/src/benchmesh_service/drivers/owon_spm.py
+++ b/benchmesh-serial-service/src/benchmesh_service/drivers/owon_spm.py
@@ -1,45 +1,18 @@
-import serial
-import time
-import logging
+from ..transport import SerialTransport
 
 class OWONSPM:
-    def __init__(self, port, baudrate=115200):
-        self.port = port
-        self.baudrate = baudrate
-        self.ser = None
-        self.connected = False
-        self.logger = logging.getLogger(__name__)
+    def __init__(self, port, baudrate=115200, serial_mode='8N1', seol='\r', reol='\r'):
+        self.t = SerialTransport(port, baudrate, serial_mode=serial_mode, seol=seol, reol=reol).open()
 
-    def connect(self):
-        try:
-            self.ser = serial.Serial(self.port, self.baudrate, timeout=1)
-            self.connected = True
-            self.logger.info(f"Connected to OWON SPM on {self.port}")
-        except serial.SerialException as e:
-            self.logger.error(f"Failed to connect to OWON SPM on {self.port}: {e}")
+    def identify(self):
+        self.t.write_line('*IDN?')
+        return self.t.read_until_reol(1024)
 
-    def disconnect(self):
-        if self.ser and self.ser.is_open:
-            self.ser.close()
-            self.connected = False
-            self.logger.info(f"Disconnected from OWON SPM on {self.port}")
+    def write(self, text: str):
+        self.t.write_line(text)
 
-    def send_command(self, command):
-        if self.connected:
-            self.ser.write(command.encode() + b'\r')
-            time.sleep(0.1)  # wait for the command to be processed
-            response = self.ser.read(1024).decode()
-            return response
-        else:
-            self.logger.warning("Attempted to send command while not connected.")
-            return None
+    def read(self, size=1024):
+        return self.t.read(size)
 
-    def check_status(self):
-        if self.connected:
-            self.logger.info("Checking status of OWON SPM.")
-            # Implement status check logic here
-        else:
-            self.logger.warning("Cannot check status, not connected.")
-
-    def __del__(self):
-        self.disconnect()
+    def close(self):
+        self.t.close()

--- a/benchmesh-serial-service/src/benchmesh_service/drivers/owon_xdm.py
+++ b/benchmesh-serial-service/src/benchmesh_service/drivers/owon_xdm.py
@@ -1,61 +1,21 @@
-import serial
-import time
-import logging
+from ..transport import SerialTransport
 
 class OWONXDM:
-    def __init__(self, port, baudrate):
-        self.port = port
-        self.baudrate = baudrate
-        self.ser = None
-        self.connected = False
+    def __init__(self, port, baudrate=115200, serial_mode='8N1', seol='\r', reol='\r'):
+        self.t = SerialTransport(port, baudrate, serial_mode=serial_mode, seol=seol, reol=reol).open()
 
-    def connect(self):
-        try:
-            self.ser = serial.Serial(
-                port=self.port,
-                baudrate=self.baudrate,
-                bytesize=serial.EIGHTBITS,
-                parity=serial.PARITY_NONE,
-                stopbits=serial.STOPBITS_ONE,
-                timeout=1.0
-            )
-            self.connected = True
-            logging.info(f"Connected to OWON XDM on {self.port}")
-        except serial.SerialException as e:
-            logging.error(f"Failed to connect to OWON XDM on {self.port}: {e}")
-            self.connected = False
+    def identify(self):
+        self.t.write_line('*IDN?')
+        return self.t.read_until_reol(1024)
 
-    def disconnect(self):
-        if self.ser and self.ser.is_open:
-            self.ser.close()
-            self.connected = False
-            logging.info(f"Disconnected from OWON XDM on {self.port}")
+    def write(self, data: bytes):
+        self.t.write(data)
 
-    def send_command(self, command):
-        if self.connected:
-            self.ser.write(command)
-            time.sleep(0.1)  # wait for the command to be processed
-            response = self.ser.read(1024)  # read response
-            return response
-        else:
-            logging.warning("Attempted to send command while not connected.")
-            return None
+    def read(self, size=1024):
+        return self.t.read(size)
 
-    def check_status(self):
-        if self.connected:
-            try:
-                self.ser.write(b'*IDN?\r')
-                time.sleep(0.1)
-                reply = self.ser.read(1024)
-                logging.info(f"Status check reply: {reply}")
-                return reply
-            except Exception as e:
-                logging.error(f"Error checking status: {e}")
-                self.disconnect()
-                return None
-        else:
-            logging.warning("Attempted to check status while not connected.")
-            return None
+    def close(self):
+        self.t.close()
 
     def is_connected(self):
-        return self.connected
+        return self.t.is_open

--- a/benchmesh-serial-service/src/benchmesh_service/drivers/tenma_psu.py
+++ b/benchmesh-serial-service/src/benchmesh_service/drivers/tenma_psu.py
@@ -1,52 +1,20 @@
-import serial
-import time
-import threading
-from src.benchmesh_service.logger import logger
+from ..transport import SerialTransport
+from ..logger import logger
 
 class TenmaPSU:
-    def __init__(self, port, baudrate=115200):
-        self.port = port
-        self.baudrate = baudrate
-        self.ser = None
-        self.is_connected = False
+    def __init__(self, port, baudrate=115200, serial_mode='8N1', seol='', reol=''):
+        # TENMA manifest declares empty EOLs
+        self.t = SerialTransport(port, baudrate, serial_mode=serial_mode, seol=seol, reol=reol).open()
 
-    def connect(self):
-        try:
-            self.ser = serial.Serial(self.port, self.baudrate, timeout=1)
-            self.is_connected = True
-            logger.info(f"Connected to TENMA PSU on {self.port}")
-        except serial.SerialException as e:
-            logger.error(f"Failed to connect to TENMA PSU: {e}")
+    def identify(self):
+        self.t.write_line('*IDN?')
+        return self.t.read_until_reol(1024)
 
-    def disconnect(self):
-        if self.ser and self.ser.is_open:
-            self.ser.close()
-            self.is_connected = False
-            logger.info("Disconnected from TENMA PSU")
+    def write(self, text: str):
+        self.t.write_line(text)
 
-    def send_command(self, command):
-        if self.is_connected:
-            self.ser.write(command.encode() + b'\r\n')
-            time.sleep(0.1)  # wait for the command to be processed
-            response = self.ser.readline().decode().strip()
-            return response
-        else:
-            logger.warning("Attempted to send command while not connected")
-            return None
+    def read(self, size=1024):
+        return self.t.read(size)
 
-    def check_status(self):
-        if self.is_connected:
-            logger.info("Checking status of TENMA PSU")
-            # Example command to check status
-            response = self.send_command("*IDN?")
-            logger.info(f"Status response: {response}")
-        else:
-            logger.warning("Cannot check status, not connected")
-
-    def start_status_check(self):
-        def status_check_loop():
-            while self.is_connected:
-                self.check_status()
-                time.sleep(0.5)  # check status every 500ms
-
-        threading.Thread(target=status_check_loop, daemon=True).start()
+    def close(self):
+        self.t.close()

--- a/benchmesh-serial-service/src/benchmesh_service/logger.py
+++ b/benchmesh-serial-service/src/benchmesh_service/logger.py
@@ -1,26 +1,33 @@
 import logging
 
+
 def setup_logger():
     logger = logging.getLogger("benchmesh_service")
+    # Avoid adding duplicate handlers if called multiple times
+    if getattr(logger, "_is_configured", False):
+        return logger
+
     logger.setLevel(logging.DEBUG)
 
-    # Create file handler
     fh = logging.FileHandler("benchmesh_service.log")
     fh.setLevel(logging.DEBUG)
 
-    # Create console handler
     ch = logging.StreamHandler()
     ch.setLevel(logging.INFO)
 
-    # Create formatter and add it to the handlers
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     fh.setFormatter(formatter)
     ch.setFormatter(formatter)
 
-    # Add the handlers to the logger
     logger.addHandler(fh)
     logger.addHandler(ch)
 
+    # Prevent propagation to root logger (avoids duplicate logs via root handlers)
+    logger.propagate = False
+    # Mark as configured
+    logger._is_configured = True
+
     return logger
+
 
 logger = setup_logger()

--- a/benchmesh-serial-service/src/benchmesh_service/serial_manager.py
+++ b/benchmesh-serial-service/src/benchmesh_service/serial_manager.py
@@ -1,28 +1,65 @@
-import serial
+import json
+import os
 import time
 import threading
-import yaml
 import logging
-from typing import Dict
+import importlib
+import inspect
+from typing import Dict, List, Any
+import yaml
 from .logger import setup_logger
 
 logger = logging.getLogger(__name__)
 
+MANIFEST_ALIASES = {
+    'tenma_psu': 'tenma_72',
+}
+
+
+def _repo_root() -> str:
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+
+def _load_manifest(driver_key: str) -> Dict:
+    here = _repo_root()
+    manifest_key = MANIFEST_ALIASES.get(driver_key, driver_key)
+    path = os.path.join(here, 'drivers', manifest_key, 'manifest.json')
+    with open(path, 'r') as f:
+        return json.load(f)
+
+
+def _load_driver_class(driver_key: str):
+    mod_name = f"benchmesh_service.drivers.{driver_key}"
+    mod = importlib.import_module(mod_name)
+    # pick the first class defined in the module
+    for name, obj in inspect.getmembers(mod, inspect.isclass):
+        if obj.__module__ == mod.__name__:
+            return obj
+    raise ImportError(f"No driver class found in module {mod_name}")
+
+
 class SerialManager:
-    def __init__(self, config_file):
-        print("Initializing SerialManager with config:", config_file)
+    def __init__(self, config_source: Any):
+        print("Initializing SerialManager with config:", config_source)
         self.logger = setup_logger()
-        self.devices = config_file
-        self.connections = {}
+        self.devices: List[Dict] = self._load_devices(config_source)
+        self.connections: Dict[str, object] = {}
         self.keep_running = True
         self.last_open_attempt: Dict[str, float] = {}
         self.last_ok: Dict[str, float] = {}
 
         self.establish_connections()
-    # def load_config(self, config_file):
-    #     with open(config_file, 'r') as file:
-    #         config = yaml.safe_load(file)
-    #     return config['devices']
+
+    def _load_devices(self, source: Any) -> List[Dict]:
+        if isinstance(source, list):
+            return source
+        # treat as path
+        cfg_path = source if isinstance(source, str) else os.path.join(_repo_root(), 'config.yaml')
+        if not os.path.isabs(cfg_path):
+            cfg_path = os.path.join(_repo_root(), cfg_path)
+        with open(cfg_path, 'r') as f:
+            cfg = yaml.safe_load(f)
+        return cfg.get('devices', [])
 
     def establish_connections(self):
         print("Establishing connections to devices...")
@@ -31,13 +68,14 @@ class SerialManager:
             try:
                 self.reconnect(device)
             except Exception as e:
-                self.logger.info(f"Failed to connect to {device['name']} on {device['port']}: {e}")
+                self.logger.info(f"Failed to connect to {device.get('name', device.get('id'))} on {device.get('port')}: {e}")
 
     def monitor_connections(self):
         print("Starting connection monitor thread.")
         while self.keep_running:
-            for device_id, connection in self.connections.items():
-                if connection.is_open:
+            for device_id, drv in self.connections.items():
+                is_open = getattr(getattr(drv, 't', None), 'is_open', False)
+                if is_open:
                     self.logger.info(f"{device_id} is connected.")
                     self.last_ok[device_id] = 0.0
                     self.last_open_attempt[device_id] = 0.0
@@ -47,11 +85,6 @@ class SerialManager:
             time.sleep(0.5)
 
     def reconnect(self, device_or_id):
-        """
-        Attempt to (re)open a connection for a single device.
-        Accepts either the device dict or its id string. Returns the new serial
-        connection on success, or None on failure.
-        """
         if isinstance(device_or_id, dict):
             dev = device_or_id
             device_id = dev.get('id')
@@ -62,27 +95,34 @@ class SerialManager:
         if not dev or not device_id:
             return None
 
-        # Close existing connection if present
+        # Close existing driver if present
         try:
             old = self.connections.get(device_id)
             if old:
-                old.close()
+                close = getattr(old, 'close', None)
+                if callable(close):
+                    close()
         except Exception:
             pass
 
-        # Open fresh connection for this device only
+        # Create driver instance using manifest EOL settings and config serial params
         try:
-            ser = serial.Serial(
-                port=dev['port'],
-                baudrate=dev['baud'],
-                bytesize=serial.EIGHTBITS,
-                parity=serial.PARITY_NONE,
-                stopbits=serial.STOPBITS_ONE,
-                timeout=1.0
+            driver_key = dev['driver']
+            cls = _load_driver_class(driver_key)
+            manifest = _load_manifest(driver_key)
+            conn = next(iter(manifest.get('models', {}).values())).get('connection', {})
+            seol = conn.get('seol', '\r')
+            reol = conn.get('reol', '\r')
+            drv = cls(
+                dev['port'],
+                dev.get('baud', 115200),
+                serial_mode=dev.get('serial', '8N1'),
+                seol=seol,
+                reol=reol,
             )
-            self.connections[device_id] = ser
+            self.connections[device_id] = drv
             self.logger.info(f"(Re)connected to {dev['name']} on {dev['port']}")
-            return ser
+            return drv
         except Exception as e:
             self.logger.error(f"Reconnection failed for {dev.get('name', device_id)}: {e}")
             self.connections[device_id] = None
@@ -95,78 +135,63 @@ class SerialManager:
 
     def stop(self):
         self.keep_running = False
-        for connection in self.connections.values():
-            connection.close()
+        for drv in self.connections.values():
+            try:
+                drv.close()
+            except Exception:
+                pass
         self.logger.info("All connections closed.")
 
     def close_connections(self):
-            for dev_id, ser in list(self.connections.items()):
-                if ser:
-                    try:
-                        ser.close()
-                        logger.info("Closed connection %s", dev_id)
-                    except Exception:
-                        logger.exception("Error closing %s", dev_id)
-                self.connections[dev_id] = None
-    
+        for dev_id, drv in list(self.connections.items()):
+            if drv:
+                try:
+                    drv.close()
+                    logger.info("Closed connection %s", dev_id)
+                except Exception:
+                    logger.exception("Error closing %s", dev_id)
+            self.connections[dev_id] = None
+
     def check_status(self):
-        """
-        Ensure each configured device has a working connection.
-        Called periodically (main() schedules every 0.5s).
-        """
         now = time.time()
         for dev in self.devices:
             dev_id = dev.get('id')
             if not dev_id:
                 continue
-            ser = self.connections.get(dev_id)
+            drv = self.connections.get(dev_id)
 
-            # If no connection, try to open (with simple backoff)
-            if ser is None:
+            if drv is None:
                 last_attempt = self.last_open_attempt.get(dev_id, 0.0)
-                # backoff 2s between attempts
                 if now - last_attempt >= 2.0:
                     self.last_open_attempt[dev_id] = now
-                    new_ser = self.reconnect(dev)
-                    if new_ser:
+                    new_drv = self.reconnect(dev)
+                    if new_drv:
                         print("Opened connection to", dev_id)
-                        self.connections[dev_id] = new_ser
+                        self.connections[dev_id] = new_drv
                         self.last_ok[dev_id] = 0.0
                 continue
 
-            # If we have a connection, probe it
             try:
-                seol = dev.get('seol', "\r")
-                # Try SCPI identity probe first, fall back to EOL if write fails
-                try:
-                    ser.write(b'*IDN?\r')
-                except Exception:
-                    try:
-                        ser.write(seol.encode('utf-8') if isinstance(seol, str) else b'\r')
-                    except Exception:
-                        pass
-
-                # brief wait then read
-                time.sleep(0.05)
-                resp = b''
-                try:
-                    resp = ser.read(256)
-                except Exception as e:
-                    # read failed -> treat as lost connection
-                    raise
-
-                if resp:
-                    self.last_ok[dev_id] = now
-                    logger.debug("Probe OK %s -> %s", dev_id, resp)
+                ident = None
+                if hasattr(drv, 'identify'):
+                    ident = drv.identify()
                 else:
-                    # no response — keep connection but log debug
+                    # fallback: try to access transport
+                    t = getattr(drv, 't', None)
+                    if t:
+                        t.write_line('*IDN?')
+                        ident = t.read_until_reol(256)
+
+                if ident:
+                    self.last_ok[dev_id] = now
+                    logger.debug("Probe OK %s -> %s", dev_id, ident)
+                else:
                     logger.debug("No response from %s on probe", dev_id)
 
             except Exception as e:
                 logger.warning("Connection error for %s: %s", dev_id, e)
-                # close and mark for reopen
                 try:
-                    ser.close()
+                    drv.close()
                 except Exception:
                     pass
                 self.connections[dev_id] = None

--- a/benchmesh-serial-service/src/benchmesh_service/transport.py
+++ b/benchmesh-serial-service/src/benchmesh_service/transport.py
@@ -1,0 +1,77 @@
+import serial
+import time
+from typing import Optional
+
+BYTESIZE_MAP = {5: serial.FIVEBITS, 6: serial.SIXBITS, 7: serial.SEVENBITS, 8: serial.EIGHTBITS}
+PARITY_MAP = {'N': serial.PARITY_NONE, 'E': serial.PARITY_EVEN, 'O': serial.PARITY_ODD, 'M': serial.PARITY_MARK, 'S': serial.PARITY_SPACE}
+STOPBITS_MAP = {1: serial.STOPBITS_ONE, 1.5: serial.STOPBITS_ONE_POINT_FIVE, 2: serial.STOPBITS_TWO}
+
+
+def parse_serial_mode(mode: str):
+    if not mode or len(mode) < 3:
+        return (serial.EIGHTBITS, serial.PARITY_NONE, serial.STOPBITS_ONE)
+    try:
+        bits = int(mode[0])
+        parity = mode[1].upper()
+        stop = float(mode[2:]) if len(mode) > 2 else 1
+        return (BYTESIZE_MAP.get(bits, serial.EIGHTBITS), PARITY_MAP.get(parity, serial.PARITY_NONE), STOPBITS_MAP.get(stop, serial.STOPBITS_ONE))
+    except Exception:
+        return (serial.EIGHTBITS, serial.PARITY_NONE, serial.STOPBITS_ONE)
+
+
+class SerialTransport:
+    def __init__(self, port: str, baudrate: int, serial_mode: str = '8N1', timeout: float = 1.0, seol: str = '\r', reol: str = '\r'):
+        self.port = port
+        self.baudrate = baudrate
+        self.timeout = timeout
+        self.seol = seol.encode() if isinstance(seol, str) else (seol or b'')
+        self.reol = reol.encode() if isinstance(reol, str) else (reol or b'')
+        self._ser: Optional[serial.Serial] = None
+        bytesize, parity, stopbits = parse_serial_mode(serial_mode)
+        self._kwargs = dict(port=self.port, baudrate=self.baudrate, bytesize=bytesize, parity=parity, stopbits=stopbits, timeout=self.timeout)
+
+    def open(self):
+        self._ser = serial.Serial(**self._kwargs)
+        time.sleep(0.05)
+        return self
+
+    def close(self):
+        if self._ser:
+            try:
+                self._ser.close()
+            finally:
+                self._ser = None
+
+    @property
+    def is_open(self) -> bool:
+        return bool(self._ser and getattr(self._ser, 'is_open', True))
+
+    def write(self, data: bytes):
+        if not self._ser:
+            raise RuntimeError('Transport not open')
+        self._ser.write(data)
+
+    def write_line(self, text: str):
+        # If seol is empty, just write the text without terminator
+        data = text.encode('utf-8') + (self.seol or b'')
+        self.write(data)
+
+    def read(self, size: int = 1024) -> bytes:
+        if not self._ser:
+            raise RuntimeError('Transport not open')
+        return self._ser.read(size)
+
+    def read_until_reol(self, max_bytes: int = 4096) -> bytes:
+        if not self._ser:
+            raise RuntimeError('Transport not open')
+        if not self.reol:
+            return self._ser.read(max_bytes)
+        buf = bytearray()
+        while len(buf) < max_bytes:
+            b = self._ser.read(1)
+            if not b:
+                break
+            buf += b
+            if buf.endswith(self.reol):
+                break
+        return bytes(buf)

--- a/benchmesh-serial-service/tests/test_driver_identify.py
+++ b/benchmesh-serial-service/tests/test_driver_identify.py
@@ -1,0 +1,70 @@
+import os
+import sys
+from unittest.mock import patch
+
+THIS_DIR = os.path.dirname(__file__)
+SRC_DIR = os.path.abspath(os.path.join(THIS_DIR, '..', 'src'))
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+from benchmesh_service.drivers.owon_oel import OwonOEL
+from benchmesh_service.drivers.owon_spm import OWONSPM
+from benchmesh_service.drivers.owon_xdm import OWONXDM
+from benchmesh_service.drivers.tenma_psu import TenmaPSU
+
+
+class FakeSerial:
+    def __init__(self, port, baudrate=115200, bytesize=None, parity=None, stopbits=None, timeout=1.0):
+        self.port = port
+        self.baudrate = baudrate
+        self.is_open = True
+        self._writes = []
+        # Provide a line-terminated generic response
+        self._buf = b"VENDOR,MODEL,1.0\r"
+
+    def write(self, data: bytes):
+        self._writes.append(bytes(data))
+
+    def read(self, n: int = 1) -> bytes:
+        if not self._buf:
+            return b""
+        data = self._buf[:n]
+        self._buf = self._buf[n:]
+        return data
+
+    def close(self):
+        self.is_open = False
+
+
+def test_identify_owon_oel_uses_cr_eol():
+    with patch('benchmesh_service.transport.serial.Serial', side_effect=lambda **kw: FakeSerial(**kw)):
+        d = OwonOEL('/dev/ttyFAKE1', 115200, serial_mode='8N1', seol='\r', reol='\r')
+        idn = d.identify().decode('utf-8', errors='ignore')
+    assert 'VENDOR' in idn
+
+
+def test_identify_owon_spm_uses_cr_eol():
+    with patch('benchmesh_service.transport.serial.Serial', side_effect=lambda **kw: FakeSerial(**kw)):
+        d = OWONSPM('/dev/ttyFAKE2', 115200, serial_mode='8N1', seol='\r', reol='\r')
+        idn = d.identify().decode('utf-8', errors='ignore')
+    assert 'VENDOR' in idn
+
+
+def test_identify_owon_xdm_uses_cr_eol():
+    with patch('benchmesh_service.transport.serial.Serial', side_effect=lambda **kw: FakeSerial(**kw)):
+        d = OWONXDM('/dev/ttyFAKE3', 115200, serial_mode='8N1', seol='\r', reol='\r')
+        idn = d.identify().decode('utf-8', errors='ignore')
+    assert 'VENDOR' in idn
+
+
+def test_identify_tenma_empty_eol():
+    # TENMA specifies empty EOLs; transport must not append EOL and should read buffered
+    class TenmaFake(FakeSerial):
+        def __init__(self, **kw):
+            super().__init__(**kw)
+            self._buf = b"TENMA 72-2540 OK"
+
+    with patch('benchmesh_service.transport.serial.Serial', side_effect=lambda **kw: TenmaFake(**kw)):
+        d = TenmaPSU('/dev/ttyFAKE4', 9600, serial_mode='8N1', seol='', reol='')
+        idn = d.identify().decode('utf-8', errors='ignore')
+    assert 'TENMA' in idn or 'OK' in idn

--- a/benchmesh-serial-service/tests/test_serial_manager.py
+++ b/benchmesh-serial-service/tests/test_serial_manager.py
@@ -45,22 +45,27 @@ def make_devices(n=3):
         devs.append({
             'id': f'dev-{i+1}',
             'name': f'Device {i+1}',
-            'driver': 'dummy',
+            'driver': 'owon_oel',
             'port': f'/dev/ttyFAKE{i+1}',
             'baud': 115200,
             'serial': '8N1',
-            'seol': '\r',
-            'reol': '\n',
         })
     return devs
 
 
+def _get_underlying_serial(m: SerialManager, dev_id: str) -> FakeSerial:
+    drv = m.connections[dev_id]
+    return getattr(getattr(drv, 't', None), '_ser', None)
+
+
 def test_establish_connections_opens_all_devices():
     devices = make_devices(4)
-    with patch('benchmesh_service.serial_manager.serial.Serial', side_effect=lambda **kw: FakeSerial(**kw)):
+    with patch('benchmesh_service.transport.serial.Serial', side_effect=lambda **kw: FakeSerial(**kw)):
         m = SerialManager(devices)
     assert set(m.connections.keys()) == {d['id'] for d in devices}
-    for dev_id, ser in m.connections.items():
+    for dev_id, drv in m.connections.items():
+        assert hasattr(drv, 't') and getattr(drv.t, 'is_open', False)
+        ser = _get_underlying_serial(m, dev_id)
         assert isinstance(ser, FakeSerial)
         assert ser.is_open is True
 
@@ -73,7 +78,7 @@ def test_establish_connections_tolerates_failures_and_continues():
             raise Exception('open failed')
         return FakeSerial(**kw)
 
-    with patch('benchmesh_service.serial_manager.serial.Serial', side_effect=serial_factory):
+    with patch('benchmesh_service.transport.serial.Serial', side_effect=serial_factory):
         m = SerialManager(devices)
     # two should be connected; the failing one may be absent or present with None
     assert devices[0]['id'] in m.connections
@@ -83,7 +88,7 @@ def test_establish_connections_tolerates_failures_and_continues():
 
 def test_check_status_probes_and_leaves_connection_on_no_response():
     devices = make_devices(1)
-    with patch('benchmesh_service.serial_manager.serial.Serial', side_effect=lambda **kw: FakeSerial(**kw)):
+    with patch('benchmesh_service.transport.serial.Serial', side_effect=lambda **kw: FakeSerial(**kw)):
         m = SerialManager(devices)
     # No response by default -> connection should remain, just logs
     m.check_status()
@@ -92,9 +97,9 @@ def test_check_status_probes_and_leaves_connection_on_no_response():
 
 def test_check_status_sets_none_on_read_exception():
     devices = make_devices(1)
-    with patch('benchmesh_service.serial_manager.serial.Serial', side_effect=lambda **kw: FakeSerial(**kw)):
+    with patch('benchmesh_service.transport.serial.Serial', side_effect=lambda **kw: FakeSerial(**kw)):
         m = SerialManager(devices)
-    ser = m.connections[devices[0]['id']]
+    ser = _get_underlying_serial(m, devices[0]['id'])
     ser._raise_on_read = True
     m.check_status()
     assert m.connections[devices[0]['id']] is None
@@ -102,11 +107,11 @@ def test_check_status_sets_none_on_read_exception():
 
 def test_check_status_writes_probe():
     devices = make_devices(1)
-    with patch('benchmesh_service.serial_manager.serial.Serial', side_effect=lambda **kw: FakeSerial(**kw)):
+    with patch('benchmesh_service.transport.serial.Serial', side_effect=lambda **kw: FakeSerial(**kw)):
         m = SerialManager(devices)
-    ser = m.connections[devices[0]['id']]
     m.check_status()
-    # Should have attempted to write a probe (*IDN? or EOL)
+    ser = _get_underlying_serial(m, devices[0]['id'])
+    # Should have attempted to write a probe (*IDN?)
     assert any(w for w in ser._written), 'Expected at least one write during probe'
 
 
@@ -121,11 +126,11 @@ def test_reconnect_backoff_and_successful_reopen(monkeypatch):
             super().__init__(**kw)
 
     # First create manager with a working connection
-    with patch('benchmesh_service.serial_manager.serial.Serial', side_effect=lambda **kw: FlakySerial(**kw)):
+    with patch('benchmesh_service.transport.serial.Serial', side_effect=lambda **kw: FlakySerial(**kw)):
         m = SerialManager(devices)
 
     # Simulate a read failure to drop the connection to None
-    ser = m.connections[devices[0]['id']]
+    ser = _get_underlying_serial(m, devices[0]['id'])
     ser._raise_on_read = True
     m.check_status()
     assert m.connections[devices[0]['id']] is None
@@ -138,7 +143,7 @@ def test_reconnect_backoff_and_successful_reopen(monkeypatch):
 
     # After backoff is satisfied, patch Serial again to succeed and ensure reopen happens
     time.sleep(2.05)
-    with patch('benchmesh_service.serial_manager.serial.Serial', side_effect=lambda **kw: FlakySerial(**kw)):
+    with patch('benchmesh_service.transport.serial.Serial', side_effect=lambda **kw: FlakySerial(**kw)):
         m.check_status()
 
     assert m.connections[devices[0]['id']] is not None


### PR DESCRIPTION
Summary
- Refactor SerialManager to dynamically load devices from config.yaml and instantiate driver classes via dynamic import
- Introduce shared SerialTransport abstraction to handle serial settings and EOLs
- Update existing drivers (owon_oel, owon_spm, owon_xdm, tenma_psu) to use the transport and implement identify() issuing `*IDN?`
- Fix logger duplication by preventing duplicate handlers and disabling propagation
- Add tests that mock pyserial via transport to validate identify() and SerialManager behavior

Changes
- benchmesh-serial-service/src/benchmesh_service/transport.py (new): SerialTransport, parse_serial_mode
- benchmesh-serial-service/src/benchmesh_service/serial_manager.py: dynamic driver import, manifest EOL injection, config.yaml loading
- benchmesh-serial-service/src/benchmesh_service/drivers/owon_oel.py: use transport, implement identify()
- benchmesh-serial-service/src/benchmesh_service/drivers/owon_spm.py: use transport, implement identify()
- benchmesh-serial-service/src/benchmesh_service/drivers/owon_xdm.py: use transport, implement identify()
- benchmesh-serial-service/src/benchmesh_service/drivers/tenma_psu.py: use transport, implement identify()
- benchmesh-serial-service/src/benchmesh_service/logger.py: avoid duplicate handlers, disable propagation
- benchmesh-serial-service/tests/test_driver_identify.py (new): tests identify() per driver
- benchmesh-serial-service/tests/test_serial_manager.py: updated to mock transport-level serial

Testing
- All tests pass locally: `pytest -q benchmesh-serial-service/tests`

Notes
- No changes to manifests or config.yaml.
- TENMA driver uses manifest alias `tenma_psu -> tenma_72` for manifest lookup.

Co-authored-by: openhands <openhands@all-hands.dev>